### PR TITLE
Allow subnets to be called by name

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -19,6 +19,11 @@ output "vnet_address_space" {
 }
 
 output "vnet_subnets" {
-  description = "The ids of subnets created inside the newl vNet"
+  description = "The ids of subnets created inside the newly created vNet"
   value       = azurerm_subnet.subnet.*.id
+}
+
+output "vnet_subnets_name_id" {
+  description = "Can be queried subnet-id by subnet name by using lookup(module.vnet.vnet_subnets_name_id, subnet1)"
+  value       = local.azurerm_subnets
 }


### PR DESCRIPTION
Allows subnets to be referred by name rather than element number

For example

lookup(module.vnet.vnet_subnets_name_id, subnet_name)

This will retrieve subnet id for the given name